### PR TITLE
Made 'withRunInIO' fully polymorphic

### DIFF
--- a/unliftio-core/ChangeLog.md
+++ b/unliftio-core/ChangeLog.md
@@ -2,6 +2,7 @@
 
 * Doc improvements.
 * Inline functions in `Control.Monad.IO.Unlift` module [#4](https://github.com/fpco/unliftio/pull/4).
+* Fully polymorphic `withRunInIO` [#12](https://github.com/fpco/unliftio/pull/12).
 
 ## 0.1.0.0
 

--- a/unliftio-core/package.yaml
+++ b/unliftio-core/package.yaml
@@ -1,5 +1,5 @@
 name:                unliftio-core
-version:             0.1.0.0
+version:             0.1.1.0
 synopsis:            The MonadUnliftIO typeclass for unlifting monads to IO
 description:         Please see the documentation and README at <https://www.stackage.org/package/unliftio-core>
 homepage:            https://github.com/fpco/unliftio/tree/master/unliftio-core#readme

--- a/unliftio-core/src/Control/Monad/IO/Unlift.hs
+++ b/unliftio-core/src/Control/Monad/IO/Unlift.hs
@@ -93,13 +93,13 @@ askRunInIO = liftM unliftIO askUnliftIO
 withUnliftIO :: MonadUnliftIO m => (UnliftIO m -> IO a) -> m a
 withUnliftIO inner = askUnliftIO >>= liftIO . inner
 
--- | Same as 'withUnliftIO', but uses a monomorphic function like
--- 'askRunInIO'.
+-- | Same as 'withUnliftIO', but uses a polymorphic function
+-- without the newtype wrapper.
 --
 -- @since 0.1.0.0
 {-# INLINE withRunInIO #-}
-withRunInIO :: MonadUnliftIO m => ((m a -> IO a) -> IO b) -> m b
-withRunInIO inner = askRunInIO >>= liftIO . inner
+withRunInIO :: MonadUnliftIO m => ((forall a. m a -> IO a) -> IO b) -> m b
+withRunInIO inner = withUnliftIO $ \u -> inner (unliftIO u)
 
 -- | Convert an action in @m@ to an action in @IO@.
 --

--- a/unliftio-core/src/Control/Monad/IO/Unlift.hs
+++ b/unliftio-core/src/Control/Monad/IO/Unlift.hs
@@ -86,7 +86,8 @@ askRunInIO :: MonadUnliftIO m => m (m a -> IO a)
 askRunInIO = liftM unliftIO askUnliftIO
 
 -- | Convenience function for capturing the monadic context and running
--- an 'IO' action.
+-- an 'IO' action. The 'UnliftIO' newtype wrapper is rarely needed, so
+-- prefer 'withRunInIO' to this function.
 --
 -- @since 0.1.0.0
 {-# INLINE withUnliftIO #-}

--- a/unliftio/package.yaml
+++ b/unliftio/package.yaml
@@ -20,7 +20,7 @@ dependencies:
   - filepath
   - stm >= 2.4.3
   - transformers
-  - unliftio-core
+  - unliftio-core >= 0.1.1.0
 
 when:
 - condition: "!os(Windows)"

--- a/unliftio/src/UnliftIO/Async.hs
+++ b/unliftio/src/UnliftIO/Async.hs
@@ -85,32 +85,32 @@ asyncOn i m = withRunInIO $ \run -> A.asyncOn i $ run m
 -- @since 0.1.0.0
 asyncWithUnmask :: MonadUnliftIO m => ((forall b. m b -> m b) -> m a) -> m (Async a)
 asyncWithUnmask m =
-  withUnliftIO $ \u -> A.asyncWithUnmask $ \unmask -> unliftIO u $ m $ liftIO . unmask . unliftIO u
+  withRunInIO $ \run -> A.asyncWithUnmask $ \unmask -> run $ m $ liftIO . unmask . run
 
 -- | Unlifted 'A.asyncOnWithUnmask'.
 --
 -- @since 0.1.0.0
 asyncOnWithUnmask :: MonadUnliftIO m => Int -> ((forall b. m b -> m b) -> m a) -> m (Async a)
 asyncOnWithUnmask i m =
-  withUnliftIO $ \u -> A.asyncOnWithUnmask i $ \unmask -> unliftIO u $ m $ liftIO . unmask . unliftIO u
+  withRunInIO $ \run -> A.asyncOnWithUnmask i $ \unmask -> run $ m $ liftIO . unmask . run
 
 -- | Unlifted 'A.withAsync'.
 --
 -- @since 0.1.0.0
 withAsync :: MonadUnliftIO m => m a -> (Async a -> m b) -> m b
-withAsync a b = withUnliftIO $ \u -> A.withAsync (unliftIO u a) (unliftIO u . b)
+withAsync a b = withRunInIO $ \run -> A.withAsync (run a) (run . b)
 
 -- | Unlifted 'A.withAsyncBound'.
 --
 -- @since 0.1.0.0
 withAsyncBound :: MonadUnliftIO m => m a -> (Async a -> m b) -> m b
-withAsyncBound a b = withUnliftIO $ \u -> A.withAsyncBound (unliftIO u a) (unliftIO u . b)
+withAsyncBound a b = withRunInIO $ \run -> A.withAsyncBound (run a) (run . b)
 
 -- | Unlifted 'A.withAsyncOn'.
 --
 -- @since 0.1.0.0
 withAsyncOn :: MonadUnliftIO m => Int -> m a -> (Async a -> m b) -> m b
-withAsyncOn i a b = withUnliftIO $ \u -> A.withAsyncOn i (unliftIO u a) (unliftIO u . b)
+withAsyncOn i a b = withRunInIO $ \run -> A.withAsyncOn i (run a) (run . b)
 
 -- | Unlifted 'A.withAsyncWithUnmask'.
 --
@@ -121,9 +121,9 @@ withAsyncWithUnmask
   -> (Async a -> m b)
   -> m b
 withAsyncWithUnmask a b =
-  withUnliftIO $ \u -> A.withAsyncWithUnmask
-    (\unmask -> unliftIO u $ a $ liftIO . unmask . unliftIO u)
-    (unliftIO u . b)
+  withRunInIO $ \run -> A.withAsyncWithUnmask
+    (\unmask -> run $ a $ liftIO . unmask . run)
+    (run . b)
 
 -- | Unlifted 'A.withAsyncOnWithMask'.
 --
@@ -135,9 +135,9 @@ withAsyncOnWithUnmask
   -> (Async a -> m b)
   -> m b
 withAsyncOnWithUnmask i a b =
-  withUnliftIO $ \u -> A.withAsyncOnWithUnmask i
-    (\unmask -> unliftIO u $ a $ liftIO . unmask . unliftIO u)
-    (unliftIO u . b)
+  withRunInIO $ \run -> A.withAsyncOnWithUnmask i
+    (\unmask -> run $ a $ liftIO . unmask . run)
+    (run . b)
 
 -- | Lifted 'A.wait'.
 --
@@ -252,25 +252,25 @@ link2 a b = liftIO (A.link2 a b)
 --
 -- @since 0.1.0.0
 race :: MonadUnliftIO m => m a -> m b -> m (Either a b)
-race a b = withUnliftIO $ \u -> A.race (unliftIO u a) (unliftIO u b)
+race a b = withRunInIO $ \run -> A.race (run a) (run b)
 
 -- | Unlifted 'A.race_'.
 --
 -- @since 0.1.0.0
 race_ :: MonadUnliftIO m => m a -> m b -> m ()
-race_ a b = withUnliftIO $ \u -> A.race_ (unliftIO u a) (unliftIO u b)
+race_ a b = withRunInIO $ \run -> A.race_ (run a) (run b)
 
 -- | Unlifted 'A.concurrently'.
 --
 -- @since 0.1.0.0
 concurrently :: MonadUnliftIO m => m a -> m b -> m (a, b)
-concurrently a b = withUnliftIO $ \u -> A.concurrently (unliftIO u a) (unliftIO u b)
+concurrently a b = withRunInIO $ \run -> A.concurrently (run a) (run b)
 
 -- | Unlifted 'A.concurrently_'.
 --
 -- @since 0.1.0.0
 concurrently_ :: MonadUnliftIO m => m a -> m b -> m ()
-concurrently_ a b = withUnliftIO $ \u -> A.concurrently_ (unliftIO u a) (unliftIO u b)
+concurrently_ a b = withRunInIO $ \run -> A.concurrently_ (run a) (run b)
 
 -- | Unlifted 'A.mapConcurrently'.
 --

--- a/unliftio/src/UnliftIO/Concurrent.hs
+++ b/unliftio/src/UnliftIO/Concurrent.hs
@@ -63,14 +63,14 @@ forkIO m = withRunInIO $ \run -> C.forkIO $ run m
 -- @since 0.1.1.0
 forkWithUnmask :: MonadUnliftIO m => ((forall a. m a -> m a) -> m ()) -> m ThreadId
 forkWithUnmask m =
-  withUnliftIO $ \u -> C.forkIOWithUnmask $ \unmask -> unliftIO u $ m $ liftIO . unmask . unliftIO u
+  withRunInIO $ \run -> C.forkIOWithUnmask $ \unmask -> run $ m $ liftIO . unmask . run
 {-# INLINABLE forkWithUnmask #-}
 
 -- | Unlifted version of 'C.forkFinally'.
 --
 -- @since 0.1.1.0
 forkFinally :: MonadUnliftIO m => m a -> (Either SomeException a -> m ()) -> m ThreadId
-forkFinally m1 m2 = withUnliftIO $ \u -> C.forkFinally (unliftIO u m1) $ unliftIO u . m2
+forkFinally m1 m2 = withRunInIO $ \run -> C.forkFinally (run m1) $ run . m2
 {-# INLINABLE forkFinally #-}
 
 -- | Lifted version of 'C.killThread'.
@@ -92,7 +92,7 @@ forkOn i m = withRunInIO $ \run -> C.forkOn i $ run m
 -- @since 0.1.1.0
 forkOnWithUnmask :: MonadUnliftIO m => Int -> ((forall a. m a -> m a) -> m ()) -> m ThreadId
 forkOnWithUnmask i m =
-  withUnliftIO $ \u -> C.forkOnWithUnmask i $ \unmask -> unliftIO u $ m $ liftIO . unmask . unliftIO u
+  withRunInIO $ \run -> C.forkOnWithUnmask i $ \unmask -> run $ m $ liftIO . unmask . run
 {-# INLINABLE forkOnWithUnmask #-}
 
 -- | Lifted version of 'C.getNumCapabilities'.


### PR DESCRIPTION
`withRunInIO` was

```haskell
withRunInIO :: MonadUnliftIO m => ((m a -> IO a) -> IO b) -> m b
```

and now it's

```haskell
withRunInIO :: MonadUnliftIO m => ((forall a. m a -> IO a) -> IO b) -> m b
```

I also replaced `withUnliftIO` by `withRunInIO` everywhere in the codebase. Docs are updated accordingly, but please verify. I think it should be mentioned somewhere in the library that `withUnliftIO` now has quite a little number of uses (basically, if you want to put a `UnliftIO m` into some data type) and `withRunInIO` is a preferable function.