### PR TITLE
Add re-export for STM.orElse function

### DIFF
--- a/unliftio/src/UnliftIO/STM.hs
+++ b/unliftio/src/UnliftIO/STM.hs
@@ -7,6 +7,7 @@ module UnliftIO.STM
   , atomically
   , retrySTM
   , checkSTM
+  , STM.orElse
 
     -- * TVar
   , STM.TVar


### PR DESCRIPTION
Currently, `unliftio` does not re-export the `orElse` STM combinator, which is an essential one to compose `STM` operations together.