### PR TITLE
Fix typo/mistake in README

### DIFF
--- a/unliftio/README.md
+++ b/unliftio/README.md
@@ -175,7 +175,7 @@ We can use `askUnliftIO` to unlift a function:
 timeout :: MonadUnliftIO m => Int -> m a -> m (Maybe a)
 timeout x y = do
   u <- askUnliftIO
-  System.Timeout.timeout x $ unliftIO u y
+  liftIO $ System.Timeout.timeout x $ unliftIO u y
 ```
 
 or more concisely using `withRunInIO`:


### PR DESCRIPTION
Type error in the example. Fix according to the default definition of "withRunInIO".

Hi, noticed this while reading the introduction of the library. It confused me for quite a few seconds until I noticed what’s missing. Hope this fix helps others coming after me.