### PR TITLE
Add wrappedWithRunInIO function

### DIFF
--- a/unliftio-core/ChangeLog.md
+++ b/unliftio-core/ChangeLog.md
@@ -1,3 +1,7 @@
+## 0.1.2.0
+
+* Add `wrappedWithRunInIO`.
+
 ## 0.1.1.0
 
 * Doc improvements.

--- a/unliftio-core/package.yaml
+++ b/unliftio-core/package.yaml
@@ -1,5 +1,5 @@
 name:                unliftio-core
-version:             0.1.1.0
+version:             0.1.2.0
 synopsis:            The MonadUnliftIO typeclass for unlifting monads to IO
 description:         Please see the documentation and README at <https://www.stackage.org/package/unliftio-core>
 homepage:            https://github.com/fpco/unliftio/tree/master/unliftio-core#readme


### PR DESCRIPTION
Since the MonadUnliftIO class methods aren't terribly intuitive, this combinator
should make the common case of writing a pass-through instance a little
easier, as discussed in #31.

I tried to make this function work with `Data.Coerce.coerce` but it didn't really work out on the first try. Since the `IdentityT` instance doesn't work this way either, I decided to not investigate this further.