### PR TITLE
unliftio-core: allow base 4.12 for GHC 8.6 compatibility.

### DIFF
--- a/unliftio-core/package.yaml
+++ b/unliftio-core/package.yaml
@@ -13,7 +13,7 @@ extra-source-files:
 - ChangeLog.md
 
 dependencies:
-  - base >= 4.5 && < 4.12
+  - base >= 4.5 && < 4.13
   - transformers >= 0.2 && < 0.6
 
 library:


### PR DESCRIPTION
There seem to be no substantive changes required for compatibility; at
least, I've not run into any issues during testing yet.

A release or revision after this is merged would be handy, please.