### PR TITLE
Briefly note cleanup function expectations, link to exception safety tutorial

### DIFF
--- a/unliftio/src/UnliftIO/Exception.hs
+++ b/unliftio/src/UnliftIO/Exception.hs
@@ -6,6 +6,10 @@
 {-# LANGUAGE ImplicitParams #-}
 -- | Unlifted "Control.Exception", with extra async exception safety
 -- and more helper functions.
+--
+-- This module works best when your cleanup functions adhere to certain
+-- expectations around exception safety and interruptible actions.
+-- For more details, see [this exception safety tutorial](https://haskell-lang.org/tutorial/exception-safety).
 module UnliftIO.Exception
   ( -- * Throwing
     throwIO


### PR DESCRIPTION
I spent quite a bit of time confused as to why `System.Timeout.timeout` wasn't working in my cleanup function before I noticed the `uninterruptibleMask` in the `bracket` source. Hopefully this saves someone else some time.