### PR TITLE
Redefine MonadUnliftIO idempotency laws

### DIFF
--- a/unliftio-core/src/Control/Monad/IO/Unlift.hs
+++ b/unliftio-core/src/Control/Monad/IO/Unlift.hs
@@ -41,15 +41,13 @@ newtype UnliftIO m = UnliftIO { unliftIO :: forall a. m a -> IO a }
 --
 -- * @unliftIO u (m >>= f) = unliftIO u m >>= unliftIO u . f@
 --
--- Instances of @MonadUnliftIO@ must also satisfy these idempotency laws:
+-- Instances of @MonadUnliftIO@ must also satisfy the idempotency law:
 --
--- * @askUnliftIO >>= \\_ -> m = m@
+-- * @askUnliftIO >>= \\u -> (liftIO . unliftIO u) m = m@
 --
--- * @liftIO . unliftIO u = id@
---
--- The first law indicates that simply calling @askUnliftIO@ __must__
--- preserve the current monadic context. The second law maintains the
--- inverse relationship @unliftIO@ has with @liftIO@.
+-- This law showcases two properties. First, 'askUnliftIO' doesn't change
+-- the monadic context, and second, @liftIO . unliftIO u@ is equivalent to
+-- @id@ IF called in the same monadic context as 'askUnliftIO'.
 --
 -- @since 0.1.0.0
 class MonadIO m => MonadUnliftIO m where

--- a/unliftio-core/src/Control/Monad/IO/Unlift.hs
+++ b/unliftio-core/src/Control/Monad/IO/Unlift.hs
@@ -41,13 +41,15 @@ newtype UnliftIO m = UnliftIO { unliftIO :: forall a. m a -> IO a }
 --
 -- * @unliftIO u (m >>= f) = unliftIO u m >>= unliftIO u . f@
 --
--- The third is a currently nameless law which ensures that the
--- current context is preserved.
+-- Instances of @MonadUnliftIO@ must also satisfy these idempotency laws:
 --
--- * @askUnliftIO >>= (\u -> liftIO (unliftIO u m)) = m@
+-- * @askUnliftIO >>= \\_ -> m = m@
 --
--- If you have a name for this, please submit it in a pull request for
--- great glory.
+-- * @liftIO . unliftIO u = id@
+--
+-- The first law indicates that simply calling @askUnliftIO@ __must__
+-- preserve the current monadic context. The second law maintains the
+-- inverse relationship @unliftIO@ has with @liftIO@.
 --
 -- @since 0.1.0.0
 class MonadIO m => MonadUnliftIO m where


### PR DESCRIPTION
The original law, `askUnliftIO >>= (\u -> liftIO (unliftIO u m)) = m`, conflates two things in my opinion: the fact that `askUnliftIO` itself doesn't modify the state, and that `liftIO`/`unliftIO` are inverse operations. So I separated these two properties into separate laws and named these the "idempotency laws" since these laws claim that the `MonadUnliftIO`-specific operations should not have side effects, but rather should only do the work of inversing `liftIO`.

Let me know what you think!