### PR TITLE
Re-export STM.orElse

### DIFF
--- a/unliftio/ChangeLog.md
+++ b/unliftio/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for unliftio
 
+## 0.2.13
+
+* Add `UnliftIO.STM.orElse`
+
 ## 0.2.12.1
 
 * Minor doc improvements

--- a/unliftio/src/UnliftIO/STM.hs
+++ b/unliftio/src/UnliftIO/STM.hs
@@ -8,6 +8,7 @@ module UnliftIO.STM
   , atomically
   , retrySTM
   , checkSTM
+  , STM.orElse
 
     -- * TVar
   , STM.TVar


### PR DESCRIPTION
This addresses the (closed) issue #27 

`orElse` is redundant with `<|>`, but used frequently in documentation,
e.g. in "Parallel and Concurrent Programming in Haskell".