### PR TITLE
Fix outdated documentation for `wrappedWithRunInIO`

### DIFF
--- a/unliftio-core/src/Control/Monad/IO/Unlift.hs
+++ b/unliftio-core/src/Control/Monad/IO/Unlift.hs
@@ -131,12 +131,13 @@ underlying transformer.
 
 > newtype AppT m a = AppT { unAppT :: ReaderT Int (ResourceT m) a }
 >   deriving (Functor, Applicative, Monad, MonadIO)
->   -- Unfortunately, deriving MonadUnliftIO does not work.
 >
+> -- Same as `deriving newtype (MonadUnliftIO)`
 > instance MonadUnliftIO m => MonadUnliftIO (AppT m) where
 >   withRunInIO = wrappedWithRunInIO AppT unAppT
 -}
 {-# INLINE wrappedWithRunInIO #-}
+{-# DEPRECATED wrappedWithRunInIO "You can derive MonadUnliftIO for newtypes in unliftio-core 0.2.0.0 and later" #-}
 wrappedWithRunInIO :: MonadUnliftIO n
                    => (n b -> m b)
                    -- ^ The wrapper, for instance @IdentityT@.

--- a/unliftio-core/src/Control/Monad/IO/Unlift.hs
+++ b/unliftio-core/src/Control/Monad/IO/Unlift.hs
@@ -126,6 +126,9 @@ toIO m = withRunInIO $ \run -> return $ run m
 Useful for the common case where you want to simply delegate to the
 underlying transformer.
 
+Note: You can derive 'MonadUnliftIO' for newtypes without this helper function
+in @unliftio-core@ 0.2.0.0 and later.
+
 @since 0.1.2.0
 ==== __Example__
 
@@ -137,7 +140,6 @@ underlying transformer.
 >   withRunInIO = wrappedWithRunInIO AppT unAppT
 -}
 {-# INLINE wrappedWithRunInIO #-}
-{-# DEPRECATED wrappedWithRunInIO "You can derive MonadUnliftIO for newtypes in unliftio-core 0.2.0.0 and later" #-}
 wrappedWithRunInIO :: MonadUnliftIO n
                    => (n b -> m b)
                    -- ^ The wrapper, for instance @IdentityT@.


### PR DESCRIPTION
Comment that inspired this change: <https://github.com/fpco/unliftio/issues/55#issuecomment-815945362>

Previously, you were unable to derive `MonadUnliftIO` using the `newtype` strategy because `askUnliftIO` was a method of the typeclass ([related issue](https://github.com/fpco/unliftio/issues/55)).

The `wrappedWithRunInIO` function is provided to help write instances of `MonadUnliftIO` for newtypes.

In `unliftio-core` 0.2.0.0 and later, `askUnliftIO` was moved out of the `MonadUnliftIO` typeclass. This makes `wrappedWithRunInIO` irrelevant.

This change deprecates that function, and updates the documentation to clarify that you can now write `deriving newtype (MonadUnliftIO)`.