### PR TITLE
[WIP] conditional compilation around at_fdcwd , at_symlink_follow

### DIFF
--- a/unliftio/cbits/file-posix.c
+++ b/unliftio/cbits/file-posix.c
@@ -11,6 +11,8 @@ int unliftio_o_tmpfile( void )
 #endif
 }
 
+#if OLD_GLIBC
+#else
 int unliftio_at_fdcwd( void )
 {
   return AT_FDCWD;
@@ -20,7 +22,7 @@ int unliftio_at_symlink_follow( void )
 {
   return AT_SYMLINK_FOLLOW;
 }
-
+#endif
 
 int unliftio_s_irusr( void )
 {

--- a/unliftio/src/UnliftIO/IO/File.hs
+++ b/unliftio/src/UnliftIO/IO/File.hs
@@ -89,7 +89,7 @@ import Data.ByteString as B (ByteString, writeFile)
 import Control.Monad.IO.Unlift
 import UnliftIO.IO (Handle, IOMode(..), withBinaryFile)
 
-#if WINDOWS
+#if (WINDOWS || OLD-GLIBC)
 
 
 ensureFileDurable = (`seq` pure ())

--- a/unliftio/unliftio.cabal
+++ b/unliftio/unliftio.cabal
@@ -22,6 +22,11 @@ extra-source-files:
     README.md
     ChangeLog.md
 
+flag old-glibc
+  description: compile with post-2016 glibc, allowing atomic file writes
+  default:     False
+  manual:      False
+
 library
   exposed-modules:
       UnliftIO
@@ -85,6 +90,8 @@ library
       c-sources:
           cbits/file-posix.c
           cbits/time-posix.c
+  if flag(old-glibc)
+     cpp-options: -DOLD_GLIBC
   default-language: Haskell2010
 
 test-suite unliftio-spec
@@ -151,3 +158,4 @@ benchmark conc-bench
     build-depends:
         unix
   default-language: Haskell2010
+


### PR DESCRIPTION
On Mac OSX, with an old XCode and glibc, unliftio doesn't compile :( ( #59  ).
I've tried adding a build flag around the problem but I can't get it to propagate down to GCC.

I understand supporting old systems might not be low priority but I figured a change along these lines would be minimally disruptive (and allow me to use unliftio on my janky old laptop!)

Looking forward to all feedback.