### PR TITLE
Add "*SyncOrAsync" variant of catch functions

### DIFF
--- a/unliftio/ChangeLog.md
+++ b/unliftio/ChangeLog.md
@@ -1,5 +1,11 @@
 # Changelog for unliftio
 
+## 0.2.17
+
+* Re-export `AsyncCancelled` in `UnliftIO.Async` [#80](https://github.com/fpco/unliftio/pull/80)
+* Add `fromAsyncException` [#80](https://github.com/fpco/unliftio/pull/80)
+* Add `catchSyncOrAsync`, `handleSyncOrAsync`, and `trySyncOrAsync` [#80](https://github.com/fpco/unliftio/pull/80)
+
 ## 0.2.16
 
 * Add `createFileLink`

--- a/unliftio/ChangeLog.md
+++ b/unliftio/ChangeLog.md
@@ -3,7 +3,7 @@
 ## 0.2.17
 
 * Re-export `AsyncCancelled` in `UnliftIO.Async` [#80](https://github.com/fpco/unliftio/pull/80)
-* Add `fromAsyncException` [#80](https://github.com/fpco/unliftio/pull/80)
+* Add `fromExceptionUnwrap` [#80](https://github.com/fpco/unliftio/pull/80)
 * Add `catchSyncOrAsync`, `handleSyncOrAsync`, and `trySyncOrAsync` [#80](https://github.com/fpco/unliftio/pull/80)
 
 ## 0.2.16

--- a/unliftio/package.yaml
+++ b/unliftio/package.yaml
@@ -1,5 +1,5 @@
 name:                unliftio
-version:             0.2.16
+version:             0.2.17
 synopsis:            The MonadUnliftIO typeclass for unlifting monads to IO (batteries included)
 description:         Please see the documentation and README at <https://www.stackage.org/package/unliftio>
 homepage:            https://github.com/fpco/unliftio/tree/master/unliftio#readme

--- a/unliftio/src/UnliftIO/Async.hs
+++ b/unliftio/src/UnliftIO/Async.hs
@@ -71,7 +71,9 @@ module UnliftIO.Async
 #endif
 
     -- * Re-exports
+#if MIN_VERSION_async(2,2,0)
     A.AsyncCancelled (..),
+#endif
   ) where
 
 import           Control.Concurrent.Async (Async)

--- a/unliftio/src/UnliftIO/Async.hs
+++ b/unliftio/src/UnliftIO/Async.hs
@@ -67,8 +67,11 @@ module UnliftIO.Async
 
 #if MIN_VERSION_base(4,8,0)
     Conc, conc, runConc,
-    ConcException (..)
+    ConcException (..),
 #endif
+
+    -- * Re-exports
+    A.AsyncCancelled (..),
   ) where
 
 import           Control.Concurrent.Async (Async)

--- a/unliftio/src/UnliftIO/Exception.hs
+++ b/unliftio/src/UnliftIO/Exception.hs
@@ -170,7 +170,7 @@ catchJust f a b = a `catch` \e -> maybe (liftIO (throwIO e)) b $ f e
 -- section in
 -- [this blog post](https://www.fpcomplete.com/blog/2018/04/async-exception-handling-haskell/).
 catchSyncOrAsync :: (MonadUnliftIO m, Exception e) => m a -> (e -> m a) -> m a
-catchSyncOrAsync = catch
+catchSyncOrAsync f g = withRunInIO $ \run -> run f `EUnsafe.catch` \e -> run (g e)
 
 -- | Flipped version of 'catch'.
 --

--- a/unliftio/src/UnliftIO/Exception.hs
+++ b/unliftio/src/UnliftIO/Exception.hs
@@ -507,19 +507,19 @@ toAsyncException e =
   where
     se = toException e
 
--- | Convert from an asynchronous exception, the inverse of 'toAsyncException'.
+-- | Convert from a possibly wrapped exception.
 --
--- For asynchronous exceptions, will unwrap all of the possible ways
--- an async exception may be thrown (i.e. both unliftio's throwTo and
--- Control.Exception's throwTo).
--- For synchronous exceptions, returns Nothing.
+-- The inverse of 'toAsyncException' and 'toSyncException'. When using those
+-- functions (or functions that use them, like 'throwTo' or 'throwIO'),
+-- 'fromException' might not be sufficient because the exception might be
+-- wrapped within 'SyncExceptionWrapper' or 'AsyncExceptionWrapper'.
 --
 -- @since 0.2.17
 fromExceptionUnwrap :: Exception e => SomeException -> Maybe e
-fromExceptionUnwrap se = do
-  case fromException se of
-    Just (AsyncExceptionWrapper e) -> cast e
-    Nothing -> fromException se
+fromExceptionUnwrap se
+  | Just (AsyncExceptionWrapper e) <- fromException se = cast e
+  | Just (SyncExceptionWrapper e) <- fromException se = cast e
+  | otherwise = fromException se
 
 -- | Check if the given exception is synchronous.
 --

--- a/unliftio/test/UnliftIO/ExceptionSpec.hs
+++ b/unliftio/test/UnliftIO/ExceptionSpec.hs
@@ -46,7 +46,7 @@ spec = do
       result `shouldBe` AsyncCancelled
     it "should catch unliftio-wrapped async exceptions" $ do
       result <- withWrappedAsyncExceptionThrown $ \m -> m `catchSyncOrAsync` return
-      fromAsyncException result `shouldBe` Just Exception1
+      fromExceptionUnwrap result `shouldBe` Just Exception1
   describe "handleSyncOrAsync" $ do
     it "should catch sync exceptions" $ do
       result <- handleSyncOrAsync return $ throwIO Exception1
@@ -56,7 +56,7 @@ spec = do
       result `shouldBe` AsyncCancelled
     it "should catch unliftio-wrapped async exceptions" $ do
       result <- withWrappedAsyncExceptionThrown $ \m -> handleSyncOrAsync return m
-      fromAsyncException result `shouldBe` Just Exception1
+      fromExceptionUnwrap result `shouldBe` Just Exception1
   describe "trySyncOrAsync" $ do
     it "should catch sync exceptions" $ do
       result <- trySyncOrAsync $ void $ throwIO Exception1
@@ -66,11 +66,13 @@ spec = do
       result `shouldBe` Left AsyncCancelled
     it "should catch unliftio-wrapped async exceptions" $ do
       result <- withWrappedAsyncExceptionThrown $ \m -> trySyncOrAsync (void m)
-      first fromAsyncException result `shouldBe` Left (Just Exception1)
+      first fromExceptionUnwrap result `shouldBe` Left (Just Exception1)
 
-  describe "fromAsyncException" $ do
+  describe "fromExceptionUnwrap" $ do
     it "should be the inverse of toAsyncException" $ do
-      fromAsyncException (toAsyncException Exception1) `shouldBe` Just Exception1
+      fromExceptionUnwrap (toAsyncException Exception1) `shouldBe` Just Exception1
+    it "should be the inverse of toSyncException" $ do
+      fromExceptionUnwrap (toSyncException Exception1) `shouldBe` Just Exception1
 
   let shouldLeft x = either (const Nothing) Just x `shouldBe` Nothing
       shouldRight x = either (Just . show) (const Nothing) x `shouldBe` Nothing

--- a/unliftio/test/UnliftIO/ExceptionSpec.hs
+++ b/unliftio/test/UnliftIO/ExceptionSpec.hs
@@ -1,10 +1,77 @@
 module UnliftIO.ExceptionSpec (spec) where
 
+import Control.Monad (void)
+import Data.Bifunctor (first)
 import Test.Hspec
 import UnliftIO
+import UnliftIO.Concurrent (threadDelay)
 
 spec :: Spec
 spec = do
+  let -- The callback will run in a thread that gets cancelled immediately,
+      -- then get Exception2 thrown synchronously after 1 second.
+      withAsyncExceptionThrown :: (IO a -> IO b) -> IO b
+      withAsyncExceptionThrown f = do
+        var <- newEmptyMVar
+        a <- async $ f $ do
+          putMVar var ()
+          threadDelay 1000000
+          throwIO Exception2
+        -- wait until thread is running, then cancel
+        takeMVar var
+        cancel a
+        -- check result
+        wait a
+      -- The callback will run in a thread that gets Exception1 thrown as
+      -- an async exception immediately, then get Exception2 thrown
+      -- synchronously after 1 second.
+      withWrappedAsyncExceptionThrown :: (IO a -> IO b) -> IO b
+      withWrappedAsyncExceptionThrown f = do
+        var <- newEmptyMVar
+        a <- async $ f $ do
+          putMVar var ()
+          threadDelay 1000000
+          throwIO Exception2
+        -- wait until thread is running, then cancel
+        takeMVar var
+        throwTo (asyncThreadId a) Exception1
+        -- check result
+        wait a
+  describe "catchSyncOrAsync" $ do
+    it "should catch sync exceptions" $ do
+      result <- (`catchSyncOrAsync` return) $ throwIO Exception1
+      result `shouldBe` Exception1
+    it "should catch async exceptions" $ do
+      result <- withAsyncExceptionThrown $ \m -> m `catchSyncOrAsync` return
+      result `shouldBe` AsyncCancelled
+    it "should catch unliftio-wrapped async exceptions" $ do
+      result <- withWrappedAsyncExceptionThrown $ \m -> m `catchSyncOrAsync` return
+      fromAsyncException result `shouldBe` Just Exception1
+  describe "handleSyncOrAsync" $ do
+    it "should catch sync exceptions" $ do
+      result <- handleSyncOrAsync return $ throwIO Exception1
+      result `shouldBe` Exception1
+    it "should catch async exceptions" $ do
+      result <- withAsyncExceptionThrown $ \m -> handleSyncOrAsync return m
+      result `shouldBe` AsyncCancelled
+    it "should catch unliftio-wrapped async exceptions" $ do
+      result <- withWrappedAsyncExceptionThrown $ \m -> handleSyncOrAsync return m
+      fromAsyncException result `shouldBe` Just Exception1
+  describe "trySyncOrAsync" $ do
+    it "should catch sync exceptions" $ do
+      result <- trySyncOrAsync $ void $ throwIO Exception1
+      result `shouldBe` Left Exception1
+    it "should catch async exceptions" $ do
+      result <- withAsyncExceptionThrown $ \m -> trySyncOrAsync (void m)
+      result `shouldBe` Left AsyncCancelled
+    it "should catch unliftio-wrapped async exceptions" $ do
+      result <- withWrappedAsyncExceptionThrown $ \m -> trySyncOrAsync (void m)
+      first fromAsyncException result `shouldBe` Left (Just Exception1)
+
+  describe "fromAsyncException" $ do
+    it "should be the inverse of toAsyncException" $ do
+      fromAsyncException (toAsyncException Exception1) `shouldBe` Just Exception1
+
   let shouldLeft x = either (const Nothing) Just x `shouldBe` Nothing
       shouldRight x = either (Just . show) (const Nothing) x `shouldBe` Nothing
   describe "pureTry" $ do

--- a/unliftio/test/UnliftIO/ExceptionSpec.hs
+++ b/unliftio/test/UnliftIO/ExceptionSpec.hs
@@ -1,6 +1,6 @@
 module UnliftIO.ExceptionSpec (spec) where
 
-import Control.Monad (void)
+import Control.Monad (void, (<=<))
 import Data.Bifunctor (first)
 import Test.Hspec
 import UnliftIO
@@ -72,7 +72,9 @@ spec = do
     it "should be the inverse of toAsyncException" $ do
       fromExceptionUnwrap (toAsyncException Exception1) `shouldBe` Just Exception1
     it "should be the inverse of toSyncException" $ do
-      fromExceptionUnwrap (toSyncException Exception1) `shouldBe` Just Exception1
+      let toAsyncToSync = toSyncException . toAsyncException
+          fromSyncFromAsyc = fromExceptionUnwrap <=< fromExceptionUnwrap
+      fromSyncFromAsyc (toAsyncToSync Exception1) `shouldBe` Just Exception1
 
   let shouldLeft x = either (const Nothing) Just x `shouldBe` Nothing
       shouldRight x = either (Just . show) (const Nothing) x `shouldBe` Nothing

--- a/unliftio/unliftio.cabal
+++ b/unliftio/unliftio.cabal
@@ -1,13 +1,13 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 57462bd1ca0ffabd88cb1b743945f84d5c6330a59b7b364445e08d6399628d80
+-- hash: 6dc6425588ff3d300e7e59ea7cb3a42401bdb810af3e566aa8bd26ec2718a3bb
 
 name:           unliftio
-version:        0.2.16
+version:        0.2.17
 synopsis:       The MonadUnliftIO typeclass for unlifting monads to IO (batteries included)
 description:    Please see the documentation and README at <https://www.stackage.org/package/unliftio>
 category:       Control


### PR DESCRIPTION
Add `catchSyncOrAsync`, `handleSyncOrAsync`, and `trySyncOrAsync`
Resolves #79 

Also adds `fromAsyncException` because there was previously no easy way to take the inverse of `toAsyncException`