### PR TITLE
Comply with BSD-3 license of `temporary` package

### DIFF
--- a/unliftio/src/UnliftIO/Temporary.hs
+++ b/unliftio/src/UnliftIO/Temporary.hs
@@ -4,6 +4,42 @@
 -- Strongly inspired by\/stolen from the <https://github.com/feuerbach/temporary> package.
 --
 -- @since 0.1.0.0
+--
+-- === __Copyright notice:__
+--
+-- The following copyright notice is taken from <https://github.com/feuerbach/temporary>
+-- and is reproduced here as part of license terms of that package, of which this module is
+-- a derivate work.
+--
+-- @
+-- Copyright
+--   (c) 2003-2006, Isaac Jones
+--   (c) 2005-2009, Duncan Coutts
+--   (c) 2008, Maximilian Bolingbroke
+--   ... and other contributors
+--
+-- All rights reserved.
+--
+-- Redistribution and use in source and binary forms, with or without modification, are permitted
+-- provided that the following conditions are met:
+--
+--     * Redistributions of source code must retain the above copyright notice, this list of
+--       conditions and the following disclaimer.
+--     * Redistributions in binary form must reproduce the above copyright notice, this list of
+--       conditions and the following disclaimer in the documentation and/or other materials
+--       provided with the distribution.
+--     * Neither the name of Maximilian Bolingbroke nor the names of other contributors may be used to
+--       endorse or promote products derived from this software without specific prior written permission.
+--
+-- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+-- IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+-- FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+-- CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+-- DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+-- DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+-- IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+-- OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-- @
 module UnliftIO.Temporary
   ( withSystemTempFile
   , withSystemTempDirectory


### PR DESCRIPTION
This is a small issue that we noticed while writing our own code based on `UnliftIO.Temporary` and looking at the copyright information. I took "strongly inspired by/stolen from" to mean that the `UnliftIO.Temporary` module is a derivative work of the `temporary` source code, so it requires this reproduction of the copyright notice. The notice is taken verbatim from the `LICENSE` file on the package's GitHub page.

*EDIT: This originally said the license was MIT - it's actually BSD-3. The commit diff hasn't changed, though.*