### PR TITLE
Fix time-osx.c for aarch64 mac

### DIFF
--- a/unliftio/cbits/time-osx.c
+++ b/unliftio/cbits/time-osx.c
@@ -1,20 +1,13 @@
 /* From https://github.com/bos/criterion */
 
 #include <mach/mach.h>
-#include <mach/mach_time.h>
-
-static mach_timebase_info_data_t timebase_info;
-static double timebase_recip;
+#include <time.h>
 
 void unliftio_inittime(void)
 {
-    if (timebase_recip == 0) {
-	mach_timebase_info(&timebase_info);
-	timebase_recip = (timebase_info.denom / timebase_info.numer) / 1e9;
-    }
 }
 
 double unliftio_gettime(void)
 {
-    return mach_absolute_time() * timebase_recip;
+    return clock_gettime_nsec_np(CLOCK_UPTIME_RAW);
 }


### PR DESCRIPTION
Based on work done in criterion here:

https://github.com/haskell/criterion/commit/607b18c001fae5744b3047d2cb52a90210b1fe31

This just uses clock_gettime_nsec_np instead of mach_absolute_time.