### PR TITLE
Add STM.flushTBQueue and STM.lengthTBQueue

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        resolver: [nightly, lts-16, lts-14, lts-12, lts-11, lts-9]
+        resolver: [nightly, lts-19, lts-18, lts-17, lts-16, lts-14]
 
     steps:
       - name: Clone project

--- a/unliftio-core/ChangeLog.md
+++ b/unliftio-core/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for unliftio-core
 
+## 0.2.0.2
+
+* Widen `base` upperbound to `< 4.17` to support ghc-9.2.
+
 ## 0.2.0.1
 
 * Remove faulty default implementation of `withRunInIO` [#56](https://github.com/fpco/unliftio/issues/56)

--- a/unliftio-core/package.yaml
+++ b/unliftio-core/package.yaml
@@ -1,5 +1,5 @@
 name:                unliftio-core
-version:             0.2.0.1
+version:             0.2.0.2
 synopsis:            The MonadUnliftIO typeclass for unlifting monads to IO
 description:         Please see the documentation and README at <https://www.stackage.org/package/unliftio-core>
 homepage:            https://github.com/fpco/unliftio/tree/master/unliftio-core#readme
@@ -13,7 +13,7 @@ extra-source-files:
 - ChangeLog.md
 
 dependencies:
-  - base >= 4.9 && < 4.16
+  - base >= 4.9 && < 4.17
   - transformers >= 0.2 && < 0.7
 
 library:

--- a/unliftio/ChangeLog.md
+++ b/unliftio/ChangeLog.md
@@ -1,5 +1,10 @@
 # Changelog for unliftio
 
+## 0.2.22.0
+
+* Add `UnliftIO.STM.flushTBQueue`
+* Add `UnliftIO.STM.lengthTBQueue`
+
 ## 0.2.21.0
 
 * Add `UnliftIO.Directory.createDirectoryLink`

--- a/unliftio/package.yaml
+++ b/unliftio/package.yaml
@@ -1,5 +1,5 @@
 name:                unliftio
-version:             0.2.21.0
+version:             0.2.22.0
 synopsis:            The MonadUnliftIO typeclass for unlifting monads to IO (batteries included)
 description:         Please see the documentation and README at <https://www.stackage.org/package/unliftio>
 homepage:            https://github.com/fpco/unliftio/tree/master/unliftio#readme
@@ -20,7 +20,7 @@ dependencies:
   - directory
   - filepath
   - process >= 1.2.0.0
-  - stm >= 2.4.3
+  - stm >= 2.5
   - time
   - transformers
   - unliftio-core >= 0.1.1.0

--- a/unliftio/src/UnliftIO/STM.hs
+++ b/unliftio/src/UnliftIO/STM.hs
@@ -73,10 +73,12 @@ module UnliftIO.STM
   , newTBQueueIO
   , STM.readTBQueue
   , STM.tryReadTBQueue
+  , STM.flushTBQueue
   , STM.peekTBQueue
   , STM.tryPeekTBQueue
   , STM.writeTBQueue
   , STM.unGetTBQueue
+  , STM.lengthTBQueue
   , STM.isEmptyTBQueue
   , STM.isFullTBQueue
   ) where


### PR DESCRIPTION
Addresses #61.

Bumped `stm` as these functions are only in [`stm >= 2.5`](https://hackage.haskell.org/package/stm-2.5.0.0/docs/Control-Concurrent-STM-TBQueue.html#v:lengthTBQueue).