### PR TITLE
Use upstream Handler and Wrappers

### DIFF
--- a/unliftio/ChangeLog.md
+++ b/unliftio/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for unliftio
 
+## (???)
+
+* `UnliftIO.Exception` re-exports the `Handler` and sync/async exception wrappers from `safe-exceptions`, instead of redefining them.
+
 ## 0.2.22.0
 
 * Add `UnliftIO.STM.flushTBQueue`

--- a/unliftio/package.yaml
+++ b/unliftio/package.yaml
@@ -20,6 +20,7 @@ dependencies:
   - directory
   - filepath
   - process >= 1.2.0.0
+  - safe-exceptions
   - stm >= 2.5
   - time
   - transformers


### PR DESCRIPTION
Fixes #101 and #102 

Question: What version should this be?  I can see an argument for major, minor, or patch.

# Major?

We're changing an exported datatype! Even though the name and constructors are identical, they still are different datatypes. Considering this extremely weird test:

```haskell
it "should be weird" $ do
    let unliftIOException = 
            UnliftIO.toSyncException ThreadKilled
    let safeException = 
            Safe.toSyncException ThreadKilled
    case (unliftIOException, safeException) of
        (SomeException e0, SomeException e1) -> 
            typeOf e0 `shouldNotBe` typeOf e1
```

This test will pass prior to this PR, and will fail after this PR, since `SyncExceptionWrapper` is now the same for both packages.

More realistically, suppose we had a library that does `UnliftIO.throwTo tid MySyncException`, and *another* library that does `Safe.throwTo tid MySyncException`. For some reason, we're using both, *and* we want to behave differently:

```haskell
blah 
    `catch` (\(UnliftIO.SyncExceptionWrapper e) -> 
        notifyUnliftIOThrewException e)
    `catch` (\Safe.SyncExceptionWrapper e) -> 
        notifySafeThrowException e)
```

Prior to this PR, this code could distinguish this behavior. After it, it cannot - the first handler will always run.

# Patch?

But this sort of behavior change is *really* small. And I'd suspect that many folks would consider it a *bug* - consider,

```haskell
import qualified Control.Monad.Catch as Catch
import qualified Control.Exception.Safe as Safe
import qualified UnliftIO.Exception as UnliftIO

-- SomeException ThreadKilled
catchThrow = Catch.throwM ThreadKilled

-- SomeException (Safe.SyncExceptionWrapper ThreadKilled)
safeThrow = Safe.throwM ThreadKilled

-- SomeException (UnliftIO.SyncExceptionWrapper ThreadKilled)
ioThrow = UnliftIO.throwIO ThreadKilled
```

If your app code or an underlying library is trying to match on `ThreadKilled`, then you may "figure it out" and instead match on `Safe.SyncExceptionWrapper` and further case on `fromException e == Just ThreadKilled`. But then you *won't* catch a `UnliftIO.SyncExceptionWrapper ThreadKilled`, and you'll have to figure out *again* why it's not working. You'll probably do `print $ typeOf exn` and then be *really* confused when you see `SyncExceptionWrapper` as the output.

# Personally,,

I'm inclined to consider this a patch change. But I'll gladly defer to the more cautious. A "minor" bump (as a compromise between major/minor) also seems reasonable.