### PR TITLE
Remove 'NOTE: this library is young' from README.md

### DIFF
--- a/unliftio/README.md
+++ b/unliftio/README.md
@@ -7,12 +7,6 @@ Provides the core `MonadUnliftIO` typeclass, a number of common
 instances, and a collection of common functions working with it.  Not
 sure what the `MonadUnliftIO` typeclass is all about? Read on!
 
-__NOTE__ This library is young, and will likely undergo some serious changes
-over time. It's also very lightly tested. That said: the core concept of
-`MonadUnliftIO` has been refined for years and is pretty solid, and even though
-the code here is lightly tested, the vast majority of it is simply apply
-`withUnliftIO` to existing functionality. Caveat emptor and all that.
-
 __NOTE__ The `UnliftIO.Exception` module in this library changes the semantics of asynchronous exceptions to be in the style of the `safe-exceptions` package, which is orthogonal to the "unlifting" concept. While this change is an improvment in most cases, it means that `UnliftIO.Exception` is not always a drop-in replacement for `Control.Exception` in advanced exception handling code. See [Async exception safety](#async-exception-safety) for details.
 
 ## Quickstart


### PR DESCRIPTION
Fixes https://github.com/fpco/unliftio/issues/121

I've opted to remove the message all-together. I don't think the rest of the message about being 'only lightly tested' make much sense either since it is in use in much of the Haskell ecosystem nowadays :muscle:.