### PR TITLE
unliftio: include hspec-discover as build tool

### DIFF
--- a/unliftio/package.yaml
+++ b/unliftio/package.yaml
@@ -68,6 +68,7 @@ tests:
   unliftio-spec:
     source-dirs:
     - test
+    build-tools: hspec-discover
     main: Spec.hs
     dependencies:
     - hspec


### PR DESCRIPTION
It is technically required to run the tests.