### PR TITLE
Remove noncanonical definitions

### DIFF
--- a/unliftio/ChangeLog.md
+++ b/unliftio/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for unliftio
 
+## 0.2.25.1
+
+* Forward compatibility with `-Wnoncanonical-monoid-instances` becoming an error
+
 ## 0.2.25.0
 
 * Add `UnliftIO.Exception.Lens`

--- a/unliftio/package.yaml
+++ b/unliftio/package.yaml
@@ -1,5 +1,5 @@
 name:                unliftio
-version:             0.2.25.0
+version:             0.2.25.1
 synopsis:            The MonadUnliftIO typeclass for unlifting monads to IO (batteries included)
 description:         Please see the documentation and README at <https://www.stackage.org/package/unliftio>
 homepage:            https://github.com/fpco/unliftio/tree/master/unliftio#readme

--- a/unliftio/src/UnliftIO/Internals/Async.hs
+++ b/unliftio/src/UnliftIO/Internals/Async.hs
@@ -510,8 +510,10 @@ instance (MonadUnliftIO m, Semigroup a) => Semigroup (Conc m a) where
 instance (Monoid a, MonadUnliftIO m) => Monoid (Conc m a) where
   mempty = pure mempty
   {-# INLINE mempty #-}
+#if !MIN_VERSION_base(4,11,0)
   mappend = liftA2 mappend
   {-# INLINE mappend #-}
+#endif
 
 -------------------------
 -- Conc implementation --


### PR DESCRIPTION
This appeases the -Wnoncanonical-monoid-instances warning. This warning exists because a future GHC release may treat noncanonical definitions as errors.

See also:
  https://gitlab.haskell.org/ghc/ghc/-/wikis/proposal/semigroup-monoid