### PR TITLE
getMonotonicTime should return the number of seconds rather than nanoseconds on osx

### DIFF
--- a/unliftio/cbits/time-osx.c
+++ b/unliftio/cbits/time-osx.c
@@ -9,5 +9,5 @@ void unliftio_inittime(void)
 
 double unliftio_gettime(void)
 {
-    return clock_gettime_nsec_np(CLOCK_UPTIME_RAW);
+    return clock_gettime_nsec_np(CLOCK_UPTIME_RAW) / 1e9;
 }


### PR DESCRIPTION
I originally described the problem I was seeing via `stack build --debug` over here: https://github.com/commercialhaskell/rio-prettyprint/issues/26 

The tldr; is stack's debug output was off by a factor of 10^9 in reporting how long things took to run. 

Sorting through the commit history I found https://github.com/fpco/unliftio/pull/91 which solved a build issue, but I think introduced this regression. 

via https://www.manpagez.com/man/3/clock_gettime_nsec_np/, clock_gettime_nsec_np returns the number of _nanoseconds_: 
<img width="621" height="49" alt="image" src="https://github.com/user-attachments/assets/5f674e4b-3cd3-4d49-a269-4b82fd495fac" />

#91 references this similar work done in the criterion PR which did have the `/ 1e9`: https://github.com/haskell/criterion/commit/607b18c001fae5744b3047d2cb52a90210b1fe31#diff-2a2fbceda772ad663c4dab2a9d6d8350662f5c4d3012819e8ec5d45574330318R8
