### PR TITLE
Try to fix macOS CI steps

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,6 +42,12 @@ jobs:
 #          restore-keys: |
 #            ${{ runner.os }}-${{ matrix.resolver }}-
 
+      - name: Setup Stack
+        uses: haskell-actions/setup@v2
+        with:
+          enable-stack: true
+          stack-no-global: true
+
       - name: Build and run tests
         shell: bash
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,8 +40,8 @@ jobs:
       - name: Install LLVM (macOS only)
         if: runner.os == 'macOS'
         run: |
-          brew install llvm@12
-          echo "/opt/homebrew/opt/llvm@12/bin" >> $GITHUB_PATH
+          brew install llvm@13
+          echo "/opt/homebrew/opt/llvm@13/bin" >> $GITHUB_PATH
 
       - name: Setup Stack
         uses: haskell-actions/setup@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,8 +40,8 @@ jobs:
       - name: Install LLVM (macOS only)
         if: runner.os == 'macOS'
         run: |
-          brew install llvm@13
-          echo "/opt/homebrew/opt/llvm@13/bin" >> $GITHUB_PATH
+          brew install llvm
+          echo "/opt/homebrew/opt/llvm/bin" >> $GITHUB_PATH
 
       - name: Setup Stack
         uses: haskell-actions/setup@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,14 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         resolver: [nightly, lts-19, lts-18, lts-17, lts-16, lts-14]
+        exclude:
+          # Exclude problematic GHC versions for macOS ARM64
+          - os: macos-latest
+            resolver: lts-17
+          - os: macos-latest
+            resolver: lts-16
+          - os: macos-latest
+            resolver: lts-14
 
     steps:
       - name: Clone project
@@ -28,6 +36,12 @@ jobs:
 #          key: ${{ runner.os }}-${{ matrix.resolver }}-${{ hashFiles('stack.yaml') }}
 #          restore-keys: |
 #            ${{ runner.os }}-${{ matrix.resolver }}-
+
+      - name: Install LLVM (macOS only)
+        if: runner.os == 'macOS'
+        run: |
+          brew install llvm@12
+          echo "/opt/homebrew/opt/llvm@12/bin" >> $GITHUB_PATH
 
       - name: Setup Stack
         uses: haskell-actions/setup@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,12 +42,6 @@ jobs:
 #          restore-keys: |
 #            ${{ runner.os }}-${{ matrix.resolver }}-
 
-      - name: Setup Stack
-        uses: haskell-actions/setup@v2
-        with:
-          enable-stack: true
-          stack-no-global: true
-
       - name: Build and run tests
         shell: bash
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,9 +14,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        resolver: [nightly, lts-19, lts-18, lts-17, lts-16, lts-14]
+        resolver: [nightly, lts-24, lts-23, lts-22, lts-21, lts-20, lts-19, lts-18, lts-17, lts-16, lts-14]
         exclude:
-          # Exclude problematic GHC versions for macOS ARM64
+          # Exclude older LTS versions for macOS ARM64 due to LLVM compatibility issues
+          # LTS 20+ use newer GHC versions that work better with current LLVM
+          - os: macos-latest
+            resolver: lts-19
+          - os: macos-latest
+            resolver: lts-18
           - os: macos-latest
             resolver: lts-17
           - os: macos-latest
@@ -36,12 +41,6 @@ jobs:
 #          key: ${{ runner.os }}-${{ matrix.resolver }}-${{ hashFiles('stack.yaml') }}
 #          restore-keys: |
 #            ${{ runner.os }}-${{ matrix.resolver }}-
-
-      - name: Install LLVM (macOS only)
-        if: runner.os == 'macOS'
-        run: |
-          brew install llvm
-          echo "/opt/homebrew/opt/llvm/bin" >> $GITHUB_PATH
 
       - name: Setup Stack
         uses: haskell-actions/setup@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,6 +29,12 @@ jobs:
 #          restore-keys: |
 #            ${{ runner.os }}-${{ matrix.resolver }}-
 
+      - name: Setup Stack
+        uses: haskell-actions/setup@v2
+        with:
+          enable-stack: true
+          stack-no-global: true
+
       - name: Build and run tests
         shell: bash
         run: |


### PR DESCRIPTION
This PR attempts to update our CI to fix a few issues.

Originally, I started off trying to fix the macOS failures, but that ended up leading me down a slightly different path. As is, I'd like to merge this anyways because I think it's an improvement, despite creating _more_ failing tests than what we started with. 

1) This expands LTS support beyond 19, showing real failures on more recent builds (nightly was already failing). 
2) It skips builds on older LTS' on macOS due to architecture constraints (specifically LLVM compatibility issues). 
3) It shows legitimate behavior failures on macOS, where `openFileFromDir`'s masking behavior may be different from linux. 
4) It also brings in the stack toolchain which apparently was required to get macOS ci running, despite working fine on the linux runners. 